### PR TITLE
Remove 'emoji' from font-family

### DIFF
--- a/source/styles/root.scss
+++ b/source/styles/root.scss
@@ -73,7 +73,7 @@ $singleColumnWidth: 640px;
 
 body {
     background: var(--background);
-    font: 16px emoji,system-ui,-apple-system,sans-serif;
+    font: 16px system-ui,-apple-system,sans-serif;
 }
 
 * {


### PR DESCRIPTION
Having 'emoji' in the primary font-family resolution order is a bit odd. My emoji font in particular turns digits black, which makes edges hard to read:

<img width="58" height="80" alt="image" src="https://github.com/user-attachments/assets/5ee8ba76-e58f-4c4c-9203-e06c376f2d79" /> <img width="203" height="84" alt="image" src="https://github.com/user-attachments/assets/bdcd9bdb-ac44-4628-bd90-50faf99c002a" />

<img width="629" height="263" alt="image" src="https://github.com/user-attachments/assets/03c1cd69-2cd5-45be-9e2f-14bcb385402e" />

A secondary problem with this is the emoji font is weird with regards to spacing:
<img width="806" height="159" alt="image" src="https://github.com/user-attachments/assets/270a290a-6cfc-44ba-9360-ebb9161ab015" />

I tested this by just editing the CSS on the running hexagony.net using devtools. Looks good with the change.
<img width="1919" height="868" alt="image" src="https://github.com/user-attachments/assets/8e622cc1-95d6-4ade-820f-5f07080c5476" />
