### PR TITLE
Remove container in GridView dispose

### DIFF
--- a/source/ts/view/GridView.ts
+++ b/source/ts/view/GridView.ts
@@ -192,6 +192,7 @@ export class GridView {
     }
 
     public dispose(): void {
+        this.cellContainer.remove();
         this.svg.removeEventListener('animationend', this.onAnimationEnd);
         this.codePanel.removeEventListener('mouseup', this.onMouseUp);
         this.focusProxy.removeEventListener('focusin', this.focus);


### PR DESCRIPTION
React 18 added a new behavior to strict mode, which we have enabled during development. In particular, it mounts/unmounts each component twice. Ref https://react.dev/blog/2022/03/29/react-v18#new-strict-mode-behaviors.

This PR fixes a problem where (during development) there could be two versions of the grid stacked on top of each other:
<img width="729" height="745" alt="image" src="https://github.com/user-attachments/assets/9f735f24-acf8-4ffd-af82-7468b070e62b" />
